### PR TITLE
Finalizado rota getChatByEmail

### DIFF
--- a/back-end/controllers/chatController.js
+++ b/back-end/controllers/chatController.js
@@ -15,11 +15,19 @@ const adminClientMessage = rescue(async (req, res) => {
 
 const getAllChats = rescue(async (_req, res) => {
   const serviceAnswer = await ChatService.getAllChats();
-  res.status(200).json(serviceAnswer);
+  return res.status(200).json(serviceAnswer);
+});
+
+const getChatByEmail = rescue(async (req, res) => {
+  const { email } = req.params;
+  const { role, email: userEmail } = req.user;
+  const serviceAnswer = await ChatService.getChatByEmail(email, role, userEmail);
+  return res.status(200).json(serviceAnswer);
 });
 
 module.exports = {
   clientAdminMessage,
   adminClientMessage,
   getAllChats,
+  getChatByEmail,
 };

--- a/back-end/controllers/chatController.test.js
+++ b/back-end/controllers/chatController.test.js
@@ -248,4 +248,15 @@ describe('chatController tests', () => {
       expect(ChatModel.registerMessages).toBeCalledTimes(1);
     });
   });
+/*   describe('Testing getChatByEmail', () => {
+    it('Test if service catch if client try acess other client history', async () => {
+      const mockReq = {
+        params: { email: 'cliente2@cliente.com' },
+        user: { email: 'cliente@cliente.com', role: 'client' },
+      };
+      const mockJson = jest.fn();
+      const mockNext = jest.fn();
+
+    })
+  }) */
 });

--- a/back-end/index.js
+++ b/back-end/index.js
@@ -28,6 +28,7 @@ app.post('/users', userController.createUser);
 app.patch('/users/me', validateJWT, userController.updateUserById);
 app.post('/users/chat', validateJWT, chatController.clientAdminMessage);
 app.get('/users/chat', validateJWT, chatController.getAllChats);
+app.get('/users/chat/:email', validateJWT, chatController.getChatByEmail);
 app.post('/users/admin/chat', validateJWT, chatController.adminClientMessage);
 
 app.get('/login', validateJWT, userController.getLoginUser);

--- a/back-end/services/ChatService.js
+++ b/back-end/services/ChatService.js
@@ -1,6 +1,7 @@
 const ChatModel = require('../mongoModels/ChatModel');
 
 const errorMsgNotSaved = { error: true, message: 'Message not saved', code: 'bad_request' };
+const errorNotFound = { error: true, message: 'Messages not found', code: 'not_found' };
 
 const clientAdminMessage = async (message, email) => {
   const existEmail = await ChatModel.emailSchemaExist(email);
@@ -32,8 +33,20 @@ const getAllChats = async () => {
     const modelAnswer = await ChatModel.getAllChats();
     return modelAnswer;
   } catch (err) {
-    const error = { error: true, message: 'Messages not found', code: 'not_found' };
+    throw errorNotFound;
+  }
+};
+
+const getChatByEmail = async (email, role, userEmail) => {
+  if (role === 'client' && email !== userEmail) {
+    const error = { error: true, message: 'You do not have permission', code: 'unauthorized' };
     throw error;
+  }
+  try {
+    const modelAnswer = await ChatModel.findClientByEmail(email);
+    return modelAnswer;
+  } catch (err) {
+    throw errorNotFound;
   }
 };
 
@@ -41,4 +54,5 @@ module.exports = {
   clientAdminMessage,
   adminClientMessage,
   getAllChats,
+  getChatByEmail,
 };

--- a/front-end/src/pages/admin/AllChatsAdmin.js
+++ b/front-end/src/pages/admin/AllChatsAdmin.js
@@ -36,15 +36,15 @@ const Conversations = () => {
               Nenhuma conversa por aqui
             </div>
           )
-          : chats.map(({ email, messages }) => (
-            <div className="containerChat" key={messages[0].time}>
-              <Link to={{ pathname: '/admin/chat', state: { email, messages } }}>
+          : chats.map(({ email, time }) => (
+            <div className="containerChat" key={time}>
+              <Link to={{ pathname: '/admin/chat', state: { email } }}>
                 <div className="containerEmail" data-testid="profile-name">
                   {email}
                 </div>
               </Link>
               <div className="containerTime" data-testid="last-message">
-                {`Última mensagem às ${new Date(messages[messages.length - 1].time)
+                {`Última mensagem às ${new Date(time)
                   .toLocaleTimeString([], { timeStyle: 'short' })}`}
               </div>
             </div>


### PR DESCRIPTION
A nova rota foi realizada para que o usuário busque apenas o próprio histórico de mensagens, no caso de um admnistrador, ele tem acesso já que recebe todas as mensagens de clientes.
A rota é realizado através do método GET no endpoint /users/chat/:email
Então é necessário enviar o e-mail do cliente no endpoint.
Quando realizar a requisição, o cliente apenas poderá realizar a requisição do histórico do próprio e-mail, caso contrário retornará um erro no mesmo padrão REST com o código de não-autorizado 401.
A rota de getAllChats eu modifiquei para que ela retorne apenas o e-mail e o timestamp da última mensagem, em ordenação decrescente, e já realizei a alteração no Front-End a respeito disso também, agora essa rota atende aos padrões REST e SOLID.
Com a nova rota o coverage caiu de 100% para 95% pois faltam os testes dessa rota.